### PR TITLE
Hide the "os" module at the top-level

### DIFF
--- a/brlcad/__init__.py
+++ b/brlcad/__init__.py
@@ -1,9 +1,9 @@
-import os
+import os as _os
 
 __all__ = []
 
-_path_bindings = os.path.join(os.path.dirname(__file__), "_bindings")
+_path_bindings = _os.path.join(_os.path.dirname(__file__), "_bindings")
 
 # The generated bindings might not exist yet and importing will fail.
-if os.path.exists(_path_bindings):
+if _os.path.exists(_path_bindings):
     __all__.append("_bindings")


### PR DESCRIPTION
There's no reason to show this module as a feature of the brlcad module
in pythonland.
