### PR TITLE
Upload "sdist" builds to pypi in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,7 @@ clean:
 sdist: clean
 	python setup.py sdist
 
+upload: clean
+	python setup.py sdist upload
+
 all: clean install


### PR DESCRIPTION
This adds a convenience target to Makefile for uploading straight to Python Package Index.
