### PR TITLE
README: recommend cygwin gcc over mingw gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,9 @@ Use either mingw or cygwin to provide gcc during installation. There is a bug
 in pip that causes a WindowsError to occur when installing this package, see
 [the bug report](https://github.com/pypa/pip/pull/1263) for more details.
 
-#### mingw
-
-Install a Windows build of gcc (probably by installing mingw and adding
-`C:\MingW\bin` to the PATH environment variable) and then run:
-
-```
-C:\Python27\Scripts\pip.exe install --upgrade brlcad
-```
-
-TODO: there may be a way to run this installation process while under `msys`
-without updating the system PATH.
+There is a bug in ctypesgen that prevents the mingw gcc method from working on
+Windows, so start with the cygwin method and then try mingw if that doesn't
+work.
 
 #### cygwin
 
@@ -55,6 +47,18 @@ During the installation, ctypesgen will make use of cygwin gcc because of the
 cygwin $PATH environment variable.
 
 There is no brlcad build that targets cygwin.
+
+#### mingw
+
+Install a Windows build of gcc (probably by installing mingw and adding
+`C:\MingW\bin` to the PATH environment variable) and then run:
+
+```
+C:\Python27\Scripts\pip.exe install --upgrade brlcad
+```
+
+TODO: there may be a way to run this installation process while under `msys`
+without updating the system PATH.
 
 ## testing
 


### PR DESCRIPTION
There is a problem on Windows with using mingw gcc during the ctypesgen step. So recommend cygwin instead of mingw.
