### PR TITLE
Fix whitespace (removed tabs)

### DIFF
--- a/brlcad/install/post_install.py
+++ b/brlcad/install/post_install.py
@@ -224,9 +224,9 @@ def main(library_path, logger=None):
         Make up the dependencies to each library so that ctypesgen will be able
         to import the relevant structures from each module.
         """
-        brlcad_libraries["wdb"]["dependencies"] += ["bu", "bn", ]
-        brlcad_libraries["rt"]["dependencies"] += ["bu", "bn", "wdb", ]
-        brlcad_libraries["ged"]["dependencies"] += ["bu", "bn", "wdb", "rt", ]
+        brlcad_libraries["rt"]["dependencies"]  += ["bu", "bn", ]
+        brlcad_libraries["wdb"]["dependencies"] += ["bu", "bn", "rt" ]
+        brlcad_libraries["ged"]["dependencies"] += ["bu", "bn", "rt", "wdb", ]
 
         # not sure about the capitalization on this one
         #brlcad_libraries["brep"]["dependencies"].append("openNURBS")


### PR DESCRIPTION
The problem was that I was using the same settings as for brlcad main code, and the editor was automatically replacing 8 spaces with a tab.
