### PR TITLE
dependency fixes; use ctypesgencore.options.get_default_options()

### DIFF
--- a/brlcad/install/post_install.py
+++ b/brlcad/install/post_install.py
@@ -18,9 +18,6 @@ import imp
 import shutil
 import glob
 
-# used for configuraing ctypesgen options
-import argparse
-
 import ctypesgencore
 
 def setup_logging(level=logging.DEBUG):
@@ -50,7 +47,7 @@ def is_py32():
 
 def is_win32():
     """
-    Check if the system is Windows.
+    Check if the system is 32 bits Windows.
     """
     return sys.platform == "win32"
 
@@ -64,8 +61,8 @@ def generate_wrapper(libname, libpath, header_path, outputfile, brlcad_install_p
     @param outputfile: location at which to dump python source code
     @param debug: toggle additional ctypesgen error/warning output
     """
-    # setup an object on which i can store some attributes
-    options = argparse.Namespace()
+    # get default options from ctypesgencore and modify what interests us
+    options = ctypesgencore.options.get_default_options()
 
     options.output = outputfile
     options.libraries = [libpath]
@@ -138,6 +135,37 @@ def cleanup_bindings_dir(bindings_path, logger):
             "_bindings wasn't previously created, so it doesn't need to be "
             "removed."
         )
+
+def setup_dependencies(brlcad_libraries):
+    """
+    Make up the dependencies to each library so that ctypesgen will be able
+    to import the relevant structures from each module.
+    """
+    brlcad_libraries["bn"]["dependencies"]  += ["bu"]
+    brlcad_libraries["brep"]["dependencies"]  += ["bu"]
+    brlcad_libraries["rt"]["dependencies"]  += ["bu", "bn"]
+    brlcad_libraries["wdb"]["dependencies"] += ["bu", "bn", "rt"]
+    brlcad_libraries["ged"]["dependencies"] += ["bu", "bn", "rt"]
+
+    # not sure about the capitalization on this one
+    #brlcad_libraries["brep"]["dependencies"].append("openNURBS")
+
+    return brlcad_libraries
+
+def setup_dependency_modules(brlcad_libraries):
+    """
+    This converts from library names to the absolute module import name so
+    that ctypesgen can access previous modules instead of re-creating the
+    same symbols multiple times.
+    """
+    for brlcad_library in brlcad_libraries.values():
+        modules = []
+        for module_name in set(brlcad_library["dependencies"]):
+            #dependency_module = "brlcad._bindings.lib{0}".format(module_name)
+            dependency_module = "lib{0}".format(module_name)
+            modules.append(dependency_module)
+        brlcad_library["dependency_modules"] = modules
+    return brlcad_libraries
 
 def main(library_path, logger=None, brlcad_install_path=os.getenv("BRLCAD_HOME", "/usr/brlcad")):
     if not logger:
@@ -218,35 +246,6 @@ def main(library_path, logger=None, brlcad_install_path=os.getenv("BRLCAD_HOME",
         logger.debug("brlcad_library_name is: {0}".format(str(brlcad_library_name)))
         logger.debug("brlcad_library_name type: {0}".format(str(type(brlcad_library_name))))
         brlcad_libraries[brlcad_library_name] = brlcad_library
-
-    def setup_dependencies(brlcad_libraries):
-        """
-        Make up the dependencies to each library so that ctypesgen will be able
-        to import the relevant structures from each module.
-        """
-        brlcad_libraries["rt"]["dependencies"]  += ["bu", "bn"]
-        brlcad_libraries["wdb"]["dependencies"] += ["bu", "bn", "rt"]
-        brlcad_libraries["ged"]["dependencies"] += ["bu", "bn", "rt"]
-
-        # not sure about the capitalization on this one
-        #brlcad_libraries["brep"]["dependencies"].append("openNURBS")
-
-        return brlcad_libraries
-
-    def setup_dependency_modules(brlcad_libraries):
-        """
-        This converts from library names to the absolute module import name so
-        that ctypesgen can access previous modules instead of re-creating the
-        same symbols multiple times.
-        """
-        for brlcad_library in brlcad_libraries.values():
-            modules = []
-            for module_name in set(brlcad_library["dependencies"]):
-                #dependency_module = "brlcad._bindings.lib{0}".format(module_name)
-                dependency_module = "lib{0}".format(module_name)
-                modules.append(dependency_module)
-            brlcad_library["dependency_modules"] = modules
-        return brlcad_libraries
 
     brlcad_libraries = setup_dependencies(brlcad_libraries)
     #brlcad_libraries = setup_dependency_modules(brlcad_libraries)


### PR DESCRIPTION
Hi Bryan,

This is a small patch again with some more dependency fixing, plus added the use of ctypesgencore.options.get_default_options()

For some reason it also contains the function move-around you did, that's likely because of lack of git experience on my side (might have mixed up some branching/merging).

Cheers,
Csaba
