### PR TITLE
Flip librt.RT_HRT_INTERNAL_MAGIC version compatibility

### DIFF
--- a/brlcad/primitives/table.py
+++ b/brlcad/primitives/table.py
@@ -64,7 +64,8 @@ MAGIC_TO_PRIMITIVE_TYPE = {
     librt.ID_CONSTRAINT: ("CONSTRAINT", Primitive, librt.RT_CONSTRAINT_MAGIC, librt.struct_rt_constraint_internal),
 }
 
-if compare_version("7.24.1") >= 0:
+# if this is version 7.24.1 or later, use RT_HRT_INTERNAL_MAGIC
+if compare_version("7.24.1") <= 0:
     MAGIC_TO_PRIMITIVE_TYPE[librt.ID_HRT] = ("HRT", Primitive, librt.RT_HRT_INTERNAL_MAGIC, librt.struct_rt_hrt_internal)
 
 

--- a/brlcad/util.py
+++ b/brlcad/util.py
@@ -21,9 +21,15 @@ def compare_version(version):
     """
     if not isinstance(version, StrictVersion):
         version = StrictVersion(version)
-    if BRLCAD_VERSION < version:
+
+    # returns 1 if the given version is bigger than the wrapped BRL-CAD version
+    if version > BRLCAD_VERSION:
         return 1
-    elif BRLCAD_VERSION > version:
+
+    # returns -1 if the given version is smaller than the wrapped BRL-CAD version
+    elif version < BRLCAD_VERSION:
         return -1
+
+    # returns 0 if the versions are equal
     else:
         return 0


### PR DESCRIPTION
Version compatibility is opposite from what was present in the source code. Also, this cleans up the compare_version function a little bit (although I think the return values are unhelpful at the moment).
