### PR TITLE
Enable building against latest BRL-CAD on macOS

### DIFF
--- a/brlcad/install/options.py
+++ b/brlcad/install/options.py
@@ -223,7 +223,7 @@ def load_brlcad_options(config):
 def find_shared_lib_file(base_dirs, lib_name):
     for base_dir in base_dirs:
         base_path = os.path.join(base_dir, lib_name)
-        for ext in [".so", ".dll"]:
+        for ext in [".so", ".dll", ".dylib"]:
             lib_path = base_path + ext
             if os.access(lib_path, os.R_OK):
                 return lib_path

--- a/brlcad/primitives/table.py
+++ b/brlcad/primitives/table.py
@@ -67,7 +67,7 @@ MAGIC_TO_PRIMITIVE_TYPE = {
     librt.ID_VOL: ("VOL", VOL, librt.RT_VOL_INTERNAL_MAGIC, librt.struct_rt_vol_internal),
     librt.ID_ARS: ("ARS", ARS, librt.RT_ARS_INTERNAL_MAGIC, librt.struct_rt_ars_internal),
     librt.ID_PNTS: ("PNTS", Primitive, librt.RT_PNTS_INTERNAL_MAGIC, librt.struct_rt_pnts_internal),
-    librt.ID_ANNOTATION: ("ANNOTATION", Primitive, librt.RT_ANNOTATION_INTERNAL_MAGIC, librt.struct_rt_annotation_internal),
+    librt.ID_ANNOT: ("ANNOTATION", Primitive, librt.RT_ANNOT_INTERNAL_MAGIC, librt.struct_rt_annot_internal),
     librt.ID_COMBINATION: ("COMBINATION", Combination, librt.RT_COMB_MAGIC, librt.struct_rt_comb_internal),
     librt.ID_CONSTRAINT: ("CONSTRAINT", Primitive, librt.RT_CONSTRAINT_MAGIC, librt.struct_rt_constraint_internal),
 }

--- a/python-brlcad.cfg
+++ b/python-brlcad.cfg
@@ -38,7 +38,7 @@ libraries: bu, bn, brep, rt, wdb, ged
 
 # You only need to explicitly specify parameters which don't fit the pattern.
 # An example is the rt library which has special header name (and now includes rtgeom.h too):
-rt-lib-headers: raytrace.h, rtgeom.h, nurb.h
+rt-lib-headers: raytrace.h,rt/shoot.h,rt/rt_instance.h,rt/seg.h,rt/op.h,rt/overlap.h,rt/solid.h,rt/debug.h,rt/db_diff.h,rt/version.h,rt/db_instance.h,rt/dspline.h,rt/tie.h,rt/misc.h,rt/piece.h,rt/application.h,rt/global.h,rt/htbl.h,rt/db5.h,rt/nmg.h,rt/binunif.h,rt/xray.h,rt/nongeom.h,rt/tree.h,rt/db_io.h,rt/private.h,rt/ray_partition.h,rt/view.h,rt/pattern.h,rt/functab.h,rt/arb_edit.h,rt/defines.h,rt/primitives/tor.h,rt/primitives/pg.h,rt/primitives/epa.h,rt/primitives/cline.h,rt/primitives/ell.h,rt/primitives/metaball.h,rt/primitives/bot.h,rt/primitives/pipe.h,rt/primitives/rhc.h,rt/primitives/dsp.h,rt/primitives/sketch.h,rt/primitives/rpc.h,rt/primitives/annot.h,rt/primitives/hf.h,rt/primitives/brep.h,rt/primitives/arb8.h,rt/primitives/tgc.h,rt/timer.h,rt/prep.h,rt/hit.h,rt/directory.h,rt/db4.h,rt/db_attr.h,rt/db_fullpath.h,rt/calc.h,rt/resource.h,rt/comb.h,rt/anim.h,rt/tol.h,rt/wdb.h,rt/vlist.h,rt/region.h,rt/func.h,rt/mem.h,rt/boolweave.h,rt/search.h,rt/soltab.h,rt/cmd.h,rt/space_partition.h,rt/geom.h,rt/mater.h,rt/db_internal.h
 # another example is libbn which needs to include symbols from vmath.h too:
 bn-lib-headers: bn.h, vmath.h
 # libbu includes symbols from magic.h:

--- a/python-brlcad.cfg
+++ b/python-brlcad.cfg
@@ -62,6 +62,7 @@ ged-dependencies: bu, bn, rt
 #
 min-brlcad-version: 7.24.0
 max-brlcad-version: 7.24.0
+rt-lib-headers: raytrace.h, rtgeom.h, nurb.h
 #
 # if changed, the full list of library names must be repeated, and order is important:
 #libraries: bu, bn, rt, wdb, ged, brep


### PR DESCRIPTION
I made some changes to get the bindings to work on macOS using the latest version of BRL-CAD. I was able to get the examples to work. In `pyhton-brlcad.cfg`, what I want to include is `rt/*.h`, and I think there is a way to specify this instead of listing the headers, but I didn't experiment.